### PR TITLE
Add system service file for binding the server to a specific interface

### DIFF
--- a/irtt@.service
+++ b/irtt@.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=irtt server
+Description=irtt server bound to interface %i
 After=network.target
+BindsTo=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
 
 [Service]
-ExecStart=/usr/bin/irtt server
+ExecStart=/usr/bin/irtt server -b %%%i
 User=nobody
 Restart=on-failure
 


### PR DESCRIPTION
This adds another systemd unit file that binds an irtt instance to a specific
interface. The unit file depends on the interface device unit, so it won't be
started until the interface is available.

Also adds Restart=on-failure to the other service file.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>