### PR TITLE
Add packet TOS option to client command

### DIFF
--- a/cconfig.go
+++ b/cconfig.go
@@ -26,6 +26,7 @@ type ClientConfig struct {
 	Handler    ClientHandler
 	ThreadLock bool
 	Supplied   *ClientConfig
+	TOS        int
 }
 
 // NewClientConfig returns a new ClientConfig with the default settings.
@@ -49,6 +50,7 @@ func NewClientConfig() *ClientConfig {
 		Timer:      DefaultTimer,
 		Waiter:     DefaultWait,
 		ThreadLock: DefaultThreadLock,
+		TOS:        DefaultTOS,
 	}
 }
 
@@ -91,6 +93,7 @@ func (c *ClientConfig) MarshalJSON() ([]byte, error) {
 		ServerFill    string        `json:"server_fill"`
 		ThreadLock    bool          `json:"thread_lock"`
 		Supplied      *ClientConfig `json:"supplied,omitempty"`
+		TOS           int           `json:"tos"`
 	}{
 		LocalAddress:  c.LocalAddress,
 		RemoteAddress: c.RemoteAddress,
@@ -107,6 +110,7 @@ func (c *ClientConfig) MarshalJSON() ([]byte, error) {
 		ServerFill:    c.ServerFill,
 		ThreadLock:    c.ThreadLock,
 		Supplied:      c.Supplied,
+		TOS:           c.TOS,
 	}
 	return json.Marshal(j)
 }

--- a/client.go
+++ b/client.go
@@ -98,6 +98,14 @@ func (c *Client) Run(ctx context.Context) (r *Result, err error) {
 		}
 	}
 
+	// set TOS
+	if c.TOS != DefaultTOS {
+		if terr := c.conn.setTOS(c.TOS); terr != nil {
+			err = Errorf(TTLError, "unable to set TOS %d (%s)", c.TOS, terr)
+			return
+		}
+	}
+
 	// create recorder
 	if c.rec, err = newRecorder(pcount(c.Duration, c.Interval), c.Handler); err != nil {
 		return

--- a/conn.go
+++ b/conn.go
@@ -23,6 +23,7 @@ type nconn struct {
 	dscpError   error
 	dscpSupport bool
 	ttl         int
+	tos         int
 	df          DF
 }
 
@@ -71,6 +72,21 @@ func (n *nconn) setTTL(ttl int) (err error) {
 	}
 	if err == nil {
 		n.ttl = ttl
+	}
+	return
+}
+
+func (n *nconn) setTOS(tos int) (err error) {
+	if n.tos == tos {
+		return
+	}
+	if n.ip4conn != nil {
+		err = n.ip4conn.SetTOS(tos)
+	} else {
+		err = n.ip6conn.SetTrafficClass(tos)
+	}
+	if err == nil {
+		n.tos = tos
 	}
 	return
 }

--- a/defaults.go
+++ b/defaults.go
@@ -11,6 +11,7 @@ const (
 	DefaultPortInt    = 2112
 	DefaultTTL        = 0
 	DefaultThreadLock = false
+	DefaultTOS        = 0
 )
 
 // Client defaults.

--- a/irtt_client.go
+++ b/irtt_client.go
@@ -107,6 +107,7 @@ func clientUsage() {
 	printf("--loose        accept and use any server restricted test parameters instead")
 	printf("               of exiting with nonzero status")
 	printf("--thread       lock sending and receiving goroutines to OS threads")
+	printf("--tos=tos      packet tos (1-255)")
 	printf("-h             show help")
 	printf("-v             show version")
 	printf("")
@@ -178,6 +179,7 @@ func runClientCLI(args []string) {
 	var ttl = fs.Int("ttl", DefaultTTL, "IP time to live")
 	var loose = fs.Bool("loose", DefaultLoose, "loose")
 	var threadLock = fs.Bool("thread", DefaultThreadLock, "thread")
+	var tos = fs.Int("tos", DefaultTOS, "Packet TOS")
 	var version = fs.BoolP("version", "v", false, "version")
 	err := fs.Parse(args)
 
@@ -316,6 +318,7 @@ func runClientCLI(args []string) {
 	cfg.HMACKey = hmacKey
 	cfg.Handler = &clientHandler{*quiet, *reallyQuiet}
 	cfg.ThreadLock = *threadLock
+	cfg.TOS = int(*tos)
 
 	// run test
 	c := NewClient(cfg)


### PR DESCRIPTION
Hi, this is my first time to write go, so if there have any coding style or idiom problem, please let me know, thanks.

Currently, TOS option is set to 0 in `conn.go/init`, this PR add a new `TOS` option to `irtt client` for user to choose which TOS level they want to use. 