### PR TITLE
Add `irtt report` command

### DIFF
--- a/cconfig.go
+++ b/cconfig.go
@@ -114,3 +114,33 @@ func (c *ClientConfig) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(j)
 }
+
+func (c *ClientConfig) UnmarshalJSON(b []byte) error {
+	j := &struct {
+		LocalAddress  string `json:"local_address"`
+		RemoteAddress string `json:"remote_address"`
+		OpenTimeouts  string `json:"open_timeouts"`
+		Params        `json:"params"`
+		Loose         bool          `json:"loose"`
+		IPVersion     IPVersion     `json:"ip_version"`
+		DF            DF            `json:"df"`
+		TTL           int           `json:"ttl"`
+		Timer         string        `json:"timer"`
+		TimeSource    string        `json:"time_source"`
+		Waiter        string        `json:"waiter"`
+		Filler        string        `json:"filler"`
+		FillOne       bool          `json:"fill_one"`
+		ServerFill    string        `json:"server_fill"`
+		ThreadLock    bool          `json:"thread_lock"`
+		Supplied      *ClientConfig `json:"supplied,omitempty"`
+	}{
+
+	}
+
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	c.Params = j.Params
+	return nil
+}

--- a/irtt.go
+++ b/irtt.go
@@ -41,6 +41,7 @@ func getCommand(name string) *command {
 func init() {
 	registerCommand("client", "runs the client", runClientCLI, clientUsage)
 	registerCommand("server", "runs the server", runServerCLI, serverUsage)
+	registerCommand("report", "read output data and display the result", runReport, reportUsage)
 	registerCommand("bench", "runs HMAC and fill benchmarks", runBench, nil)
 	registerCommand("timer", "runs timer resolution test", runTimer, nil)
 	registerCommand("clock", "runs wall vs monotonic clock test", runClock, nil)

--- a/irtt_report.go
+++ b/irtt_report.go
@@ -1,0 +1,33 @@
+package irtt
+
+import (
+	"io/ioutil"
+	"encoding/json"
+)
+
+func reportUsage() {
+	setBufio()
+	printf("Usage: report output.json")
+	printf("")
+}
+	
+func runReport(argv []string) {
+	if (len(argv) != 1) {
+		usageAndExit(reportUsage, exitCodeBadCommandLine)
+	}
+
+	dat, err := ioutil.ReadFile(argv[0])
+	if err != nil {
+		panic(err)
+	}
+
+	var r *Result
+	json.Unmarshal([]byte(dat), &r)
+	r.SendRate = calculateBitrate(r.Stats.BytesSent,
+		r.Stats.LastSent.Sub(r.Stats.FirstSend))
+	r.ReceiveRate = calculateBitrate(r.Stats.BytesReceived,
+		r.Stats.LastReceived.Sub(r.Stats.FirstReceived))
+	r.ExpectedPacketsSent = pcount(r.Stats.LastSent.Sub(r.Stats.FirstSend),
+		r.Config.Interval)
+	printResult(r)
+}

--- a/params.go
+++ b/params.go
@@ -2,6 +2,7 @@ package irtt
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"time"
 )
 
@@ -195,4 +196,27 @@ func putString(b []byte, s string, maxLen int) (n int) {
 	n += binary.PutUvarint(b[n:], uint64(l))
 	n += copy(b[n:], s[:l])
 	return
+}
+
+func (p *Params) UnmarshalJSON(b []byte) error {
+	var f map[string] *json.RawMessage
+	json.Unmarshal(b, &f)
+
+	var v map[string]interface{}
+	json.Unmarshal(*f["params"], &v)
+
+	p.ProtocolVersion = int(v["proto_version"].(float64))
+	p.Duration = time.Duration(v["duration"].(float64))
+	p.Interval = time.Duration(v["interval"].(float64))
+	p.Length = int(v["length"].(float64))
+	rs, _:= ParseReceivedStats(v["received_stats"].(string))
+	p.ReceivedStats = rs
+	stamp, _:= ParseStampAt(v["stamp_at"].(string))
+	p.StampAt = stamp
+	clock, _ := ParseClock(v["clock"].(string))
+	p.Clock = clock
+	p.DSCP = int(v["dscp"].(float64))
+	p.ServerFill = v["server_fill"].(string)
+
+	return nil
 }

--- a/recorder.go
+++ b/recorder.go
@@ -17,10 +17,10 @@ import (
 // all recording should be done internally.
 type Recorder struct {
 	Start                 Time            `json:"start_time"`
-	FirstSend             Time            `json:"-"`
-	LastSent              Time            `json:"-"`
-	FirstReceived         Time            `json:"-"`
-	LastReceived          Time            `json:"-"`
+	FirstSend             Time            `json:"first_send"`
+	LastSent              Time            `json:"last_sent"`
+	FirstReceived         Time            `json:"first_received"`
+	LastReceived          Time            `json:"last_received"`
 	SendCallStats         DurationStats   `json:"send_call"`
 	TimerErrorStats       DurationStats   `json:"timer_error"`
 	RTTStats              DurationStats   `json:"rtt"`


### PR DESCRIPTION
This make irtt can reproduce the result and display on the screen from output json file

```
$ irtt report output.json

                        Min    Mean  Median     Max  Stddev
                        ---    ----  ------     ---  ------
                RTT   1.5ms  2.02ms  1.99ms  5.59ms   238µs
         send delay  -1.28s  -1.28s  -1.28s  -1.27s   858µs
      receive delay   1.28s   1.28s   1.28s   1.28s   831µs
                                                           
      IPDV (jitter)   201ns   175µs  69.7µs  3.57ms   287µs
          send IPDV    25ns   142µs  55.4µs  1.55ms   219µs
       receive IPDV      0s  47.4µs  23.1µs  3.49ms   163µs
                                                           
     send call time  7.35µs  41.2µs          91.6µs  12.9µs
        timer error     7ns  16.7µs           189µs  22.4µs
  server proc. time  7.56µs  21.9µs            55µs  3.38µs

                duration: 10s (wait 16.76ms)
   packets sent/received: 983/983 (0.00% loss)
 server packets received: 983/983 (0.00%/0.00% loss up/down)
     bytes sent/received: 169076/169076
       send/receive rate: 135.4 Kbps / 135.4 Kbps
           packet length: 172 bytes
             timer stats: 17/1000 (1.70%) missed, 0.17% error
```