### PR TITLE
Add GCMode flag on the client to disable GC

### DIFF
--- a/cconfig.go
+++ b/cconfig.go
@@ -25,6 +25,7 @@ type ClientConfig struct {
 	FillOne    bool
 	HMACKey    []byte
 	Handler    ClientHandler
+	GCMode     GCMode
 	ThreadLock bool
 	Supplied   *ClientConfig
 }
@@ -50,6 +51,7 @@ func NewClientConfig() *ClientConfig {
 		Timer:      DefaultTimer,
 		TimeSource: DefaultTimeSource,
 		Waiter:     DefaultWait,
+		GCMode:     DefaultGCMode,
 		ThreadLock: DefaultThreadLock,
 	}
 }
@@ -92,6 +94,7 @@ func (c *ClientConfig) MarshalJSON() ([]byte, error) {
 		Filler        string        `json:"filler"`
 		FillOne       bool          `json:"fill_one"`
 		ServerFill    string        `json:"server_fill"`
+		GCMode        string        `json:"gc_mode"`
 		ThreadLock    bool          `json:"thread_lock"`
 		Supplied      *ClientConfig `json:"supplied,omitempty"`
 	}{
@@ -109,6 +112,7 @@ func (c *ClientConfig) MarshalJSON() ([]byte, error) {
 		Filler:        fstr,
 		FillOne:       c.FillOne,
 		ServerFill:    c.ServerFill,
+		GCMode:        c.GCMode.String(),
 		ThreadLock:    c.ThreadLock,
 		Supplied:      c.Supplied,
 	}

--- a/client.go
+++ b/client.go
@@ -109,11 +109,14 @@ func (c *Client) Run(ctx context.Context) (r *Result, err error) {
 	// wait group for goroutine completion
 	wg := sync.WaitGroup{}
 
-	// collect before test
-	runtime.GC()
+	// if requested, act on runtime GC
+	if c.GCMode == GCOff {
+		// collect before test
+		runtime.GC()
 
-	// disable GC
-	debug.SetGCPercent(-1)
+		// disable GC
+		debug.SetGCPercent(-1)
+	}
 
 	// start receive
 	var rerr error

--- a/defaults.go
+++ b/defaults.go
@@ -11,6 +11,7 @@ const (
 	DefaultPortInt    = 2112
 	DefaultTTL        = 0
 	DefaultThreadLock = false
+	DefaultGCMode     = GCOn
 )
 
 // Client defaults.
@@ -73,7 +74,6 @@ const (
 	DefaultAllowStamp    = DualStamps
 	DefaultAllowDSCP     = true
 	DefaultSetSrcIP      = false
-	DefaultGCMode        = GCOn
 )
 
 // DefaultBindAddrs are the default bind addresses.

--- a/irtt_client.go
+++ b/irtt_client.go
@@ -107,6 +107,9 @@ func clientUsage() {
 	printf("--ttl=ttl      time to live (default %d, meaning use OS default)", DefaultTTL)
 	printf("--loose        accept and use any server restricted test parameters instead")
 	printf("               of exiting with nonzero status")
+	printf("--gc=mode      sets garbage collection mode (default %s)", DefaultGCMode)
+	printf("               on: garbage collector always on")
+	printf("               off: garbage collector always off")
 	printf("--thread       lock sending and receiving goroutines to OS threads")
 	printf("-h             show help")
 	printf("-v             show version")
@@ -178,6 +181,7 @@ func runClientCLI(args []string) {
 	var timeoutsStr = fs.String("timeouts", DefaultOpenTimeouts.String(), "open timeouts")
 	var ttl = fs.Int("ttl", DefaultTTL, "IP time to live")
 	var loose = fs.Bool("loose", DefaultLoose, "loose")
+	var gcModeStr = fs.String("gc", DefaultGCMode.String(), "gc mode")
 	var threadLock = fs.Bool("thread", DefaultThreadLock, "thread")
 	var version = fs.BoolP("version", "v", false, "version")
 	err := fs.Parse(args)
@@ -291,6 +295,9 @@ func runClientCLI(args []string) {
 		os.Exit(exitCodeDoubleSignal)
 	}()
 
+	// parse GC mode
+	gcMode, err := ParseGCMode(*gcModeStr)
+
 	// create config
 	cfg := NewClientConfig()
 	cfg.LocalAddress = *laddrStr
@@ -316,6 +323,7 @@ func runClientCLI(args []string) {
 	cfg.HMACKey = hmacKey
 	cfg.Handler = &clientHandler{*quiet, *reallyQuiet}
 	cfg.ThreadLock = *threadLock
+	cfg.GCMode = gcMode
 
 	// run test
 	c := NewClient(cfg)


### PR DESCRIPTION
This PR adds the ability for the client to disable the GC like the server.

Warning : it breaks the current behaviour. DefaultGCMode is on by default, reusing it makes the client to avoid stopping the GC. Then you have to explicitely pass --gc=off to the client if you want it to stop the GC.

It's broken but it's aligning both client and server with the same behaviour.

If you don't want it to break things, I can add a DefaultClientGCMode to define a different behaviour.