### PR TITLE
Send all packets with the same DSCP field

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -227,6 +227,7 @@ func (c *cconn) open(ctx context.Context) (err error) {
 	}
 	sp.setPayload(params.bytes())
 	sp.updateHMAC()
+	sp.dscp = c.cfg.DSCP
 	var received bool
 	for _, to := range c.cfg.OpenTimeouts {
 		err = c.send(sp)


### PR DESCRIPTION
irtt --dscp=N sends the first packet with DSCP 0 which can cause issues with stateful network devices on the path which register dscp=0 for the udp pseudo-connection. This fix sets the same DSCP field on the first and following packets.