### PR TITLE
Add docker stuff.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.11 AS build
+
+COPY . /opt/irtt
+
+RUN apk --update add go git
+RUN go get ./opt/irtt
+RUN cd /opt/irtt && go install -v ./cmd/irtt
+
+
+FROM alpine:3.11
+
+COPY --from=build /root/go/bin/irtt /opt
+
+ENTRYPOINT ["/opt/irtt"]
+CMD []

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+# Docker
+
+It is possible to run IRTT using [Docker](https://docs.docker.com/install/).
+
+
+## Client
+
+The [irtt](irtt) wrapper script is provided to run IRTT using Docker with some
+sane defaults. To use privileged options (i.e. using low ports) you might need
+the adjust the script to run as `root`.
+
+
+## Server
+
+The IRTT server can be run using [Docker
+Compose](https://docs.docker.com/compose/). The `docker-compose.yml` file can be
+used as a starting point to run a public IRTT server.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  irtt:
+    image: liske/irtt
+    network_mode: host
+    read_only: true
+    user: nobody
+    command: server

--- a/docker/irtt
+++ b/docker/irtt
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+USER=nobody
+IMAGE=liske/irtt
+
+exec docker run --rm -it --network=host --read-only "--user=$USER" "$IMAGE" $@


### PR DESCRIPTION
This PR adds a Dockerfile which can be used to build a IRTT docker image. A Docker Compose file to run IRTT server and a small wrapper script to run IRTT on the cli is included.