### PR TITLE
Added --ecn server option to ship ECN bits (currently IPv6 only)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Added --ecn server option to ship ECN bits (currently IPv6 only)
+
 ## 0.9.1 - 2021-05-18
 
 ### Added

--- a/defaults.go
+++ b/defaults.go
@@ -73,6 +73,7 @@ const (
 	DefaultAllowStamp    = DualStamps
 	DefaultAllowDSCP     = true
 	DefaultSetSrcIP      = false
+	DefaultSetECN        = false
 )
 
 // DefaultBindAddrs are the default bind addresses.

--- a/doc/irtt-server.md
+++ b/doc/irtt-server.md
@@ -104,6 +104,9 @@ irtt server [*args*]
     unspecified IP addresses (use for more reliable reply routing, but
     increases per-packet heap allocations)
 
+\--ecn
+:   Ship ECN bits to be logged by the client.  Forces --set-src-ip, disables UDP replies from server
+
 \--thread
 :   Lock request handling goroutines to OS threads
 

--- a/irtt_server.go
+++ b/irtt_server.go
@@ -64,6 +64,7 @@ func serverUsage() {
 	printf("--set-src-ip   set source IP address on all outgoing packets from listeners")
 	printf("               on unspecified IP addresses (use for more reliable reply")
 	printf("               routing, but increases per-packet heap allocations)")
+	printf("--ecn          Ship ECN bits to be logged by the client.  Forces --set-src-ip, disables UDP replies")
 	printf("--thread       lock request handling goroutines to OS threads")
 	printf("-h             show help")
 	printf("-v             show version")
@@ -99,6 +100,7 @@ func runServerCLI(args []string) {
 	var ttl = fs.Int("ttl", DefaultTTL, "IP time to live")
 	var noDSCP = fs.Bool("no-dscp", !DefaultAllowDSCP, "no DSCP")
 	var setSrcIP = fs.Bool("set-src-ip", DefaultSetSrcIP, "set source IP")
+	var ecn = fs.Bool("ecn", DefaultSetECN, "enable ECN capture - disables UDP replies from server")
 	var lockOSThread = fs.Bool("thread", DefaultThreadLock, "thread")
 	var version = fs.BoolP("version", "v", false, "version")
 	fs.Parse(args)
@@ -158,7 +160,7 @@ func runServerCLI(args []string) {
 	cfg.TTL = *ttl
 	cfg.Handler = handler
 	cfg.IPVersion = ipVer
-	cfg.SetSrcIP = *setSrcIP
+	cfg.SetSrcIP = *setSrcIP || *ecn
 	cfg.ThreadLock = *lockOSThread
 
 	// create server

--- a/packet.go
+++ b/packet.go
@@ -183,6 +183,7 @@ type packet struct {
 	srcIP   net.IP
 	dstIP   net.IP
 	dscp    int
+	ecn     int
 }
 
 func newPacket(tlen int, cap int, hmacKey []byte) *packet {

--- a/recorder.go
+++ b/recorder.go
@@ -132,6 +132,9 @@ func (r *Recorder) recordReceive(p *packet, sts *Timestamp) bool {
 	// check for lateness
 	late := seqno < r.lastSeqno
 
+	// Transfer ECN from packet so it will be dumped
+	rtd.Ecn = p.ecn
+
 	// check for duplicate (don't update stats for duplicates)
 	if !rtd.Client.Receive.IsZero() {
 		r.Duplicates++
@@ -196,6 +199,7 @@ type RoundTripData struct {
 	Client         Timestamp `json:"client"`
 	Server         Timestamp `json:"server"`
 	receivedWindow ReceivedWindow
+	Ecn            int
 }
 
 // ReplyReceived returns true if a reply was received from the server.


### PR DESCRIPTION
The smaller, cleaner pull request I promised.

This meets Dave's stated request to be able to see what if anything has been done to the ECN bits between the irtt server and the client.

Note that the new --ecn server option and the existing --set-src-ip have the same effect, forcing the server not to use UDP for replies. I was trying to disturb the existing code as little as possible, your call whether to merge or rename these options.

I'm working on enabling --ecn for IPv4 as well.